### PR TITLE
fix: Use an environment variable for Postgres's password

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A PostgreSQL docker image with [pg_tle](https://github.com/aws/pg_tle) enabled.
 
 1. Build the container with `docker build --tag postgres-pgtle .`
 
-2. Stand up the container with `docker compose up`.
+2. Stand up the container with `export POSTGRES_PASSWORD="<your-password"> docker compose up`.
 
 3. Connect to the database with `psql -p postgres://0.0.0.0:5430 -U postgres`
-   with your password set in the docker-compose file.
+   with your password being the environment variable from above.
 
 4. Inside `psql`, run `\dx`. You should see `pgtle` in there.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 127.0.0.1:5430:5432
     environment:
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - PGDATA=/var/pgdata/data
     command: -c shared_preload_libraries=pg_tle
     volumes:


### PR DESCRIPTION
Hardcoded passwords are a no-no. Use an environment variable instead.

Closes #2 