### PR TITLE
Amend psql example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A PostgreSQL docker image with [pg_tle](https://github.com/aws/pg_tle) enabled.
 
 2. Stand up the container with `POSTGRES_PASSWORD="<your-password>" docker compose up`.
 
-3. Connect to the database with `psql -p postgres://0.0.0.0:5430 -U postgres`
+3. Connect to the database with `psql postgres://0.0.0.0:5430 -U postgres`
    with your password being the environment variable from above.
 
 4. Inside `psql`, run `\dx`. You should see `pgtle` in there.


### PR DESCRIPTION
# What it does

- We don't need a `-p` here in the connection string. This commit amends that.

# How to test it

:eyes: 